### PR TITLE
Add Chrome extension for Instagram session insights

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,0 +1,38 @@
+let sessionId = null;
+
+function applyRule() {
+  const rule = sessionId
+    ? [{
+        id: 1,
+        priority: 1,
+        action: {
+          type: "modifyHeaders",
+          requestHeaders: [{ header: "X-Session-ID", operation: "set", value: sessionId }]
+        },
+        condition: {
+          urlFilter: "https://www.instagram.com/",
+          resourceTypes: ["xmlhttprequest"]
+        }
+      }]
+    : [];
+
+  chrome.declarativeNetRequest.updateDynamicRules(
+    { removeRuleIds: [1], addRules: rule },
+    () => {}
+  );
+}
+
+function updateSessionId() {
+  chrome.cookies.get({ url: "https://www.instagram.com/", name: "sessionid" }, (cookie) => {
+    sessionId = cookie ? cookie.value : null;
+    applyRule();
+  });
+}
+
+chrome.cookies.onChanged.addListener((changeInfo) => {
+  if (changeInfo.cookie.domain.includes("instagram.com") && changeInfo.cookie.name === "sessionid") {
+    updateSessionId();
+  }
+});
+
+updateSessionId();

--- a/chrome-extension/content-script.js
+++ b/chrome-extension/content-script.js
@@ -1,0 +1,39 @@
+function parseCount(text) {
+  if (!text) return 0;
+  const normalized = text.replace(/,/g, '').toLowerCase();
+  const match = normalized.match(/([0-9.]+)([km]?)/);
+  if (!match) return 0;
+  let value = parseFloat(match[1]);
+  const suffix = match[2];
+  if (suffix === 'k') value *= 1000;
+  if (suffix === 'm') value *= 1000000;
+  return value;
+}
+
+function showEngagement() {
+  if (!/^\/[^\/]+\/$/.test(window.location.pathname)) return;
+  const counts = document.querySelectorAll('header li span span');
+  if (counts.length < 2) return;
+  const posts = parseCount(counts[0].textContent);
+  const followers = parseCount(counts[1].textContent);
+  if (!posts || !followers) return;
+  const engagement = ((posts / followers) * 100).toFixed(2);
+
+  const badge = document.createElement('div');
+  badge.textContent = `Interaction Rate: ${engagement}%`;
+  badge.style.position = 'fixed';
+  badge.style.bottom = '10px';
+  badge.style.right = '10px';
+  badge.style.padding = '6px 10px';
+  badge.style.background = 'rgba(0,0,0,0.7)';
+  badge.style.color = '#fff';
+  badge.style.fontSize = '14px';
+  badge.style.zIndex = '9999';
+  document.body.appendChild(badge);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', showEngagement);
+} else {
+  showEngagement();
+}

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,18 @@
+{
+  "manifest_version": 3,
+  "name": "Instagram Stats Extension",
+  "version": "1.0",
+  "description": "Injects session ID and shows interaction rate on Instagram profiles.",
+  "permissions": ["cookies", "declarativeNetRequest"],
+  "host_permissions": ["https://www.instagram.com/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://www.instagram.com/*"],
+      "js": ["content-script.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/statsbase-frontend/src/App.jsx
+++ b/statsbase-frontend/src/App.jsx
@@ -11,7 +11,8 @@ function App() {
   const [coldStart, setColdStart] = useState(false);
   const [sessionid, setSessionid] = useState("");
 
-  const fetchUserData = async (username) => {
+  const fetchUserData = async (name) => {
+    setUsername(name);
     if (!sessionid) {
       alert("Önce Instagram sessionID girin.");
       return;
@@ -24,7 +25,7 @@ function App() {
     const timeout = setTimeout(() => setColdStart(true), 3000);
 
     try {
-      const res = await fetch(`http://127.0.0.1:8000/api/instagram/${username}`, {
+      const res = await fetch(`http://127.0.0.1:8000/api/instagram/${name}`, {
         headers: {
           "X-IG-Session": sessionid
         }


### PR DESCRIPTION
## Summary
- switch session header injection from webRequest to declarativeNetRequest dynamic rule
- drop webRequestBlocking permission in the extension manifest to support Manifest V3

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895d02456a4832aafb099c603ad9071